### PR TITLE
Distinguish mean vs sum values for the counters

### DIFF
--- a/examples/WebAPIExample/appsettings.Development.json
+++ b/examples/WebAPIExample/appsettings.Development.json
@@ -19,7 +19,8 @@
           "Filters": [
             "cpu-usage",
             "active-timer-count",
-            "working-set"
+            "working-set",
+            "alloc-rate"
           ]
         }
       ]

--- a/src/DotNet.Diagnostics.Counters/ICounterPayload.cs
+++ b/src/DotNet.Diagnostics.Counters/ICounterPayload.cs
@@ -6,6 +6,10 @@ public interface ICounterPayload
 
     double Value { get; }
 
+    /// <summary>
+    /// There are 2 types at this point, Sum and Mean. When it is Sum, the value is an incremental between the previous value and the current one. The actual value is the sum of the current to all previous ones.
+    /// When it is mean, it is the current value.
+    /// </summary>
     string CounterType { get; }
 
     string Provider { get; }

--- a/src/DotNet.Diagnostics.Counters/Payloads/CounterPayload.cs
+++ b/src/DotNet.Diagnostics.Counters/Payloads/CounterPayload.cs
@@ -15,7 +15,8 @@ internal class CounterPayload : ICounterPayload
 
     public float Interval { get; init; }
 
-    public string CounterType { get; init; } = default!;
+    internal CounterType CounterTypeInternal { get; } = DotNet.Diagnostics.Counters.CounterType.Mean;
+    public string CounterType => CounterTypeInternal.ToString();
 
     public string Provider { get; init; } = default!;
 

--- a/src/DotNet.Diagnostics.Counters/Payloads/CounterType.cs
+++ b/src/DotNet.Diagnostics.Counters/Payloads/CounterType.cs
@@ -1,0 +1,7 @@
+namespace DotNet.Diagnostics.Counters;
+
+public enum CounterType
+{
+    Sum,
+    Mean,
+}

--- a/src/DotNet.Diagnostics.Counters/Payloads/IncrementingCounterPayload.cs
+++ b/src/DotNet.Diagnostics.Counters/Payloads/IncrementingCounterPayload.cs
@@ -8,7 +8,8 @@ internal class IncrementingCounterPayload : ICounterPayload
 
     public double Value { get; init; }
 
-    public string CounterType { get; init; } = "Sum";
+    internal CounterType CounterTypeInternal { get; } = DotNet.Diagnostics.Counters.CounterType.Sum;
+    public string CounterType => CounterTypeInternal.ToString();
 
     public string Provider { get; init; } = default!;
 


### PR DESCRIPTION
Result:

![image](https://github.com/xiaomi7732/DotNetDiagnostics/assets/3674549/245231b2-a397-4863-8ad2-53a877a0123a)

1. Add a column of 'CounterType' in the csv result.
2. Unit will show " / sec" for an indicator of the sum counter.

This addresses #29 